### PR TITLE
Add service worker and install prompt for PWA support

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,72 @@
+const CACHE_VERSION = "v1";
+const CACHE_NAME = `matchbuddy-cache-${CACHE_VERSION}`;
+const ASSETS = [
+  "/",
+  "/index.html",
+  "/manifest.json",
+  "/favicon.png",
+  "/privacy.html"
+];
+
+self.addEventListener("install", (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(ASSETS))
+  );
+  self.skipWaiting();
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
+    caches
+      .keys()
+      .then((keys) =>
+        Promise.all(keys.filter((key) => key !== CACHE_NAME).map((key) => caches.delete(key)))
+      )
+  );
+  self.clients.claim();
+});
+
+self.addEventListener("fetch", (event) => {
+  if (event.request.method !== "GET") {
+    return;
+  }
+
+  const url = new URL(event.request.url);
+
+  if (url.origin !== self.location.origin) {
+    event.respondWith(fetch(event.request));
+    return;
+  }
+
+  if (event.request.mode === "navigate") {
+    event.respondWith(
+      fetch(event.request)
+        .then((response) => {
+          const copy = response.clone();
+          caches.open(CACHE_NAME).then((cache) => cache.put(event.request, copy));
+          return response;
+        })
+        .catch(async () => {
+          const cachedResponse = await caches.match(event.request);
+          return cachedResponse || caches.match("/index.html");
+        })
+    );
+    return;
+  }
+
+  event.respondWith(
+    caches.match(event.request).then((cachedResponse) => {
+      if (cachedResponse) {
+        return cachedResponse;
+      }
+
+      return fetch(event.request)
+        .then((response) => {
+          const copy = response.clone();
+          caches.open(CACHE_NAME).then((cache) => cache.put(event.request, copy));
+          return response;
+        })
+        .catch(() => caches.match("/index.html"));
+    })
+  );
+});

--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -1,10 +1,9 @@
 import { Outlet, Link, useLocation } from "react-router-dom";
 import logo from "../assets/logo.svg"; // ← Pfad prüfen
-import ThemeToggle from "./ThemeToggle";
 import BottomNav from "./BottomNav";
 import { useState } from "react";
 import FeedbackModal from "./FeedbackModal";
-
+import PwaInstallPrompt from "./PwaInstallPrompt";
 
 export default function Layout() {
   const location = useLocation();
@@ -14,12 +13,10 @@ export default function Layout() {
     <div className="min-h-screen bg-base-200 text-base-content flex flex-col">
       {/* HEADER */}
       <header className="navbar bg-base-100 shadow-md sticky top-0 z-40">
-
         <div className="flex-1 px-4 font-heading text-xl text-primary">
-         <Link to="/" className="flex items-center gap-2">
-        <img src={logo} alt="MatchBuddy" className="h-32 cursor-pointer" />
-      </Link>
-          
+          <Link to="/" className="flex items-center gap-2">
+            <img src={logo} alt="MatchBuddy" className="h-32 cursor-pointer" />
+          </Link>
         </div>
 
         <nav className="hidden sm:flex gap-2 mr-4">
@@ -27,23 +24,19 @@ export default function Layout() {
             { path: "/", label: "Start" },
             { path: "/profil", label: "Profil" },
             { path: "/neues-spiel", label: "Meine Spiele" },
-            { path: "/spiele", label: "Spiele" },                        
+            { path: "/spiele", label: "Spiele" },
           ].map(({ path, label }) => (
             <Link
               key={path}
               to={path}
               className={`btn btn-ghost btn-sm text-sm ${
-                location.pathname === path
-                  ? "btn-active text-primary font-semibold"
-                  : ""
+                location.pathname === path ? "btn-active text-primary font-semibold" : ""
               }`}
             >
               {label}
             </Link>
           ))}
         </nav>
-
-        
       </header>
 
       {/* ZENTRALER CONTAINER */}
@@ -53,43 +46,32 @@ export default function Layout() {
         </div>
       </main>
 
-    
+      {/* FOOTER – sitzt bewusst über der fixen BottomNav */}
+      <footer className="bg-base-100 border-t border-base-300 py-4 text-center text-sm text-base-content/70 mb-[calc(env(safe-area-inset-bottom)+4rem)] sm:mb-0">
+        <p>© {new Date().getFullYear()} MatchBuddy – Entwickelt für Trainerinnen und Trainer 💚</p>
+        <div className="flex justify-center gap-4 mt-1">
+          <a href="/privacy.html" rel="noopener noreferrer" className="hover:underline">
+            Datenschutzerklärung
+          </a>
+          |
+          <a
+            href="#feedback"
+            onClick={(e) => {
+              e.preventDefault();
+              setFeedbackOpen(true);
+            }}
+            className="hover:underline cursor-pointer"
+          >
+            Feedback
+          </a>
+        </div>
+      </footer>
 
-     {/* FOOTER – sitzt bewusst über der fixen BottomNav */}
-<footer className="bg-base-100 border-t border-base-300 py-4 text-center text-sm text-base-content/70 mb-[calc(env(safe-area-inset-bottom)+4rem)] sm:mb-0">
-  <p>© {new Date().getFullYear()} MatchBuddy – Entwickelt für Trainerinnen und Trainer 💚</p>
-  <div className="flex justify-center gap-4 mt-1">
-    <a
-      href="/privacy.html"
-      rel="noopener noreferrer"
-      className="hover:underline"
-    >
-      Datenschutzerklärung
-    </a>
-    |
-    <a
-  href="#feedback"
-  onClick={(e) => {
-    e.preventDefault();
-    setFeedbackOpen(true);
-  }}
-  className="hover:underline cursor-pointer"
->
-  Feedback
-</a>
-  </div>
-</footer>
+      {/* Feedback Modal */}
+      <FeedbackModal isOpen={isFeedbackOpen} onClose={() => setFeedbackOpen(false)} />
 
-{/* Feedback Modal */}
-<FeedbackModal
-  isOpen={isFeedbackOpen}
-  onClose={() => setFeedbackOpen(false)}
-/>
-
-
+      <PwaInstallPrompt />
       <BottomNav />
-
-
     </div>
   );
 }

--- a/src/components/PwaInstallPrompt.jsx
+++ b/src/components/PwaInstallPrompt.jsx
@@ -1,0 +1,114 @@
+import { useEffect, useState } from "react";
+
+function checkStandalone() {
+  if (typeof window === "undefined") {
+    return false;
+  }
+
+  const mediaQuery = window.matchMedia?.("(display-mode: standalone)");
+
+  return Boolean(mediaQuery?.matches || window.navigator.standalone === true);
+}
+
+export default function PwaInstallPrompt() {
+  const [deferredPrompt, setDeferredPrompt] = useState(null);
+  const [isVisible, setIsVisible] = useState(false);
+  const [isStandalone, setIsStandalone] = useState(() => checkStandalone());
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return undefined;
+    }
+
+    const mediaQuery = window.matchMedia?.("(display-mode: standalone)");
+
+    const updateStandalone = () => {
+      setIsStandalone(checkStandalone());
+    };
+
+    updateStandalone();
+
+    if (mediaQuery) {
+      if (mediaQuery.addEventListener) {
+        mediaQuery.addEventListener("change", updateStandalone);
+      } else if (mediaQuery.addListener) {
+        mediaQuery.addListener(updateStandalone);
+      }
+    }
+
+    return () => {
+      if (mediaQuery) {
+        if (mediaQuery.removeEventListener) {
+          mediaQuery.removeEventListener("change", updateStandalone);
+        } else if (mediaQuery.removeListener) {
+          mediaQuery.removeListener(updateStandalone);
+        }
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || isStandalone) {
+      return undefined;
+    }
+
+    const handleBeforeInstallPrompt = (event) => {
+      event.preventDefault();
+      setDeferredPrompt(event);
+      setIsVisible(true);
+    };
+
+    const handleAppInstalled = () => {
+      setIsVisible(false);
+      setDeferredPrompt(null);
+      setIsStandalone(true);
+    };
+
+    window.addEventListener("beforeinstallprompt", handleBeforeInstallPrompt);
+    window.addEventListener("appinstalled", handleAppInstalled);
+
+    return () => {
+      window.removeEventListener("beforeinstallprompt", handleBeforeInstallPrompt);
+      window.removeEventListener("appinstalled", handleAppInstalled);
+    };
+  }, [isStandalone]);
+
+  const handleInstall = async () => {
+    if (!deferredPrompt) {
+      return;
+    }
+
+    deferredPrompt.prompt();
+    await deferredPrompt.userChoice;
+
+    setDeferredPrompt(null);
+    setIsVisible(false);
+  };
+
+  const handleDismiss = () => {
+    setIsVisible(false);
+  };
+
+  if (isStandalone || !isVisible) {
+    return null;
+  }
+
+  return (
+    <div className="alert alert-info shadow-lg fixed bottom-24 left-4 right-4 z-50 sm:left-auto sm:right-4 sm:w-96 sm:bottom-6">
+      <div className="flex flex-col gap-1">
+        <span className="font-semibold text-base">MatchBuddy installieren</span>
+        <span className="text-sm opacity-80">
+          Füge MatchBuddy deinem Startbildschirm hinzu, um jederzeit schnell loszulegen.
+        </span>
+      </div>
+      <div className="flex gap-2">
+        <button type="button" className="btn btn-ghost btn-sm" onClick={handleDismiss}>
+          Später
+        </button>
+        <button type="button" className="btn btn-primary btn-sm" onClick={handleInstall}>
+          Installieren
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -4,6 +4,14 @@ import { BrowserRouter } from "react-router-dom";
 import App from "./App";
 import "./index.css";
 
+if (import.meta.env.PROD && "serviceWorker" in navigator) {
+  navigator.serviceWorker
+    .register("/sw.js")
+    .catch((error) => {
+      console.error("Service Worker registration failed:", error);
+    });
+}
+
 ReactDOM.createRoot(document.getElementById("root")).render(
   <React.StrictMode>
     <BrowserRouter>


### PR DESCRIPTION
## Summary
- register a production service worker and add a custom PWA install prompt component to the layout
- add a service worker script with basic offline caching for core assets
- wire the service worker registration into the React entry point so browsers detect the app as installable

## Testing
- npm run build
- npm run lint *(fails: existing lint errors in AgeDropdown.jsx, MapView.jsx, Games.jsx, Home.jsx, NewGame.jsx, tailwind.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68e536b0f3bc83329240f649146fd6f5