### PR TITLE
Add visual team strength legend

### DIFF
--- a/src/components/TeamStrengthLegend.jsx
+++ b/src/components/TeamStrengthLegend.jsx
@@ -1,0 +1,58 @@
+import clsx from "clsx";
+import { TEAM_STRENGTH_LEVELS } from "../data/teamStrengthLevels";
+
+export default function TeamStrengthLegend({ className }) {
+  return (
+    <section
+      className={clsx(
+        "rounded-3xl border border-emerald-100 bg-white/80 p-6 shadow-md shadow-emerald-100/70",
+        "backdrop-blur",
+        className
+      )}
+    >
+      <div className="space-y-1 text-center sm:text-left">
+        <h2 className="text-2xl font-semibold text-emerald-700">🏆 Teamstärke-Legende</h2>
+        <p className="text-sm text-slate-600">
+          Hilft dir, euer Niveau realistisch einzuschätzen – damit faire Matches entstehen.
+        </p>
+      </div>
+
+      <div className="mt-6 grid gap-4 sm:grid-cols-2">
+        {TEAM_STRENGTH_LEVELS.map((level) => (
+          <article
+            key={level.value}
+            className="group flex flex-col gap-3 rounded-2xl border border-slate-100 bg-slate-50/80 p-4 text-left shadow-sm transition hover:border-emerald-200 hover:bg-white"
+          >
+            <div className="flex items-start justify-between gap-3">
+              <div className="space-y-1">
+                <p className="inline-flex items-center gap-1 rounded-full bg-emerald-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-emerald-700">
+                  Stärke {level.value}
+                </p>
+                <h3 className="text-lg font-semibold text-slate-900">{level.label}</h3>
+              </div>
+            </div>
+            <p className="text-sm text-slate-600">{level.short}</p>
+            <details className="group/details mt-auto text-sm">
+              <summary className="flex cursor-pointer list-none items-center gap-2 text-sm font-semibold text-emerald-600 transition hover:text-emerald-700">
+                <span>Mehr erfahren</span>
+                <svg
+                  className="h-4 w-4 transition group-open/details:rotate-180"
+                  viewBox="0 0 20 20"
+                  fill="currentColor"
+                  aria-hidden="true"
+                >
+                  <path
+                    fillRule="evenodd"
+                    d="M5.23 7.21a.75.75 0 0 1 1.06.02L10 10.94l3.71-3.71a.75.75 0 1 1 1.06 1.06l-4.24 4.25a.75.75 0 0 1-1.06 0L5.21 8.29a.75.75 0 0 1 .02-1.08z"
+                    clipRule="evenodd"
+                  />
+                </svg>
+              </summary>
+              <p className="mt-3 rounded-xl bg-white/80 p-3 text-slate-600 shadow-inner">{level.description}</p>
+            </details>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/data/teamStrengthLevels.js
+++ b/src/data/teamStrengthLevels.js
@@ -1,0 +1,72 @@
+export const TEAM_STRENGTH_LEVELS = [
+  {
+    value: 1,
+    label: "Neu am Start",
+    short: "Frisch gegründetes Team, sucht erste Gegner zum Reinschnuppern.",
+    description:
+      "Team besteht aus vielen neuen Spielern, wenig eingespielt, noch keine konstante Formation oder Spielpraxis. Häufig deutlich unterlegen gegen erfahrene Gegner.",
+  },
+  {
+    value: 2,
+    label: "Aufbauphase",
+    short: "Wir sammeln Spielpraxis und finden uns als Team.",
+    description:
+      "Erste Saison oder Freundschaftsspiele; Taktik und Positionen werden erprobt, Fokus liegt auf Spaß und Entwicklung.",
+  },
+  {
+    value: 3,
+    label: "In Entwicklung",
+    short: "Schon etwas Erfahrung, aber noch unkonstant.",
+    description:
+      "Teamstruktur vorhanden, aber Leistung schwankt stark; Spiele teils klar, teils knapp; oft gegen gleichstarke Gegner ausgeglichen.",
+  },
+  {
+    value: 4,
+    label: "Stabil im Aufbau",
+    short: "Wir halten gut mit und werden konstanter.",
+    description:
+      "Eingespielte Mannschaft mit klaren Rollen; meist ausgeglichene Spiele, teils Siege gegen ähnlich starke Teams.",
+  },
+  {
+    value: 5,
+    label: "Solide eingespielt",
+    short: "Konstante Leistungen, gute Teamchemie.",
+    description:
+      "Team mit stabilem Kader, taktisch solide, kein klarer Leistungsfokus, aber gute Basis. Gegen schwächere Gegner oft überlegen.",
+  },
+  {
+    value: 6,
+    label: "Wettbewerbsfähig",
+    short: "Spielen regelmäßig auf Augenhöhe mit guten Teams.",
+    description:
+      "Gute Balance aus Technik, Taktik und Athletik; Spiele meist offen; regelmäßig Teilnahme an Turnieren/Ligen.",
+  },
+  {
+    value: 7,
+    label: "Leistungsorientiert",
+    short: "Ambitioniert, trainiert regelmäßig und strukturiert.",
+    description:
+      "Klare Spielphilosophie, hohe Trainingsbeteiligung, gutes Passspiel & Positionsverständnis; auf Kreisliga-Topniveau.",
+  },
+  {
+    value: 8,
+    label: "Starkes Leistungs-Team",
+    short: "Auf hohem Niveau unterwegs, sucht echte Herausforderungen.",
+    description:
+      "Überdurchschnittlich stark in Technik und Taktik, spielt regelmäßig Turniere oder Testspiele gegen stärkere Gegner; Trainingsintensität über Durchschnitt.",
+  },
+  {
+    value: 9,
+    label: "Top-Team im Kreis",
+    short: "Kaum schwache Spiele, sucht Gegner auf Augenhöhe.",
+    description:
+      "Dominiert häufig in der Liga, stark in allen Mannschaftsteilen, klare Spielstruktur; gewinnt gegen 90 % der Gegner.",
+  },
+  {
+    value: 10,
+    label: "Elite-Niveau",
+    short: "Spielt regelmäßig gegen Auswahl- oder NLZ-Teams.",
+    description:
+      "Nahe am Leistungszentrum: technisch, taktisch und körperlich sehr stark; kann als Benchmark-Team dienen.",
+  },
+];

--- a/src/pages/NewGame.jsx
+++ b/src/pages/NewGame.jsx
@@ -12,6 +12,7 @@ import {
 import { db } from "../firebase";
 import { useUserLocation } from "../hooks/useUserLocation";
 import { useProfile } from "../hooks/useProfile";
+import TeamStrengthLegend from "../components/TeamStrengthLegend";
 import { formatDateGerman } from "../utils/date";
 import { generateAgeGroups, normalizeAgeGroup } from "../utils/ageGroups";
 
@@ -334,6 +335,10 @@ export default function NewGame() {
                 ))}
               </select>
             </label>
+
+            <div className="sm:col-span-2">
+              <TeamStrengthLegend />
+            </div>
 
             <label className="space-y-2 text-sm font-medium text-slate-700">
               <span>Spielort</span>


### PR DESCRIPTION
## Summary
- add a reusable TeamStrengthLegend card that lists all 10 strength levels with optional detail toggles
- store the team strength level content locally so the UI stays self-contained
- embed the legend in the new game form to help trainers judge their team strength selection

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e7eb4dfae08332ac8e1c9c9b0c390c